### PR TITLE
Remove peer dependencies package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,10 +12,6 @@
   "license": "MIT",
   "licenseFilename": "LICENSE",
   "readmeFilename": "README.md",
-  "peerDependencies": {
-    "react": "^16.8.1",
-    "react-native": ">=0.60.0-rc.0 <1.0.x"
-  },
   "devDependencies": {
     "react": "^16.9.0",
     "react-native": "^0.61.5"


### PR DESCRIPTION
I think the peer dependencies are not needed and they can cause unnecessary errors. Also having React in there means package.json would need to be updated on each new React release, even though it would already work as it is.